### PR TITLE
ci: use elfwatch

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -39,3 +39,18 @@ jobs:
             -Dsonar.projectKey=zoftko_felf-cli
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.go.coverage.reportPaths=.coverage.out
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - name: Build
+        env:
+          CGO_ENABLED: 0
+        run: go build -trimpath
+      - uses: zoftko/elfwatch-action@main
+        with:
+          file: felf-cli
+          token: ${{ secrets.ELF_WATCH_TOKEN }}


### PR DESCRIPTION
ELF Watch has been added mostly to showcase it.
Sort of a bootstrap. Coming full circle.
    
Please note that reproducible go builds are a recent thing, and I don't
claim I have achieved them, so reported sizes on the CI may differ from
locally built binaries.