### PR TITLE
feat: don't follow http redirects

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -75,7 +75,12 @@ func pushPayload(token string, url string, payload *Payload) (*http.Response, er
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/json")
 
-	return http.DefaultClient.Do(req)
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	return client.Do(req)
 }
 
 func newSize(file *elf.File) Size {


### PR DESCRIPTION
This prevents false positives like the following (which should not happen anyways but just in case...):

1. Push payload to server
2. Server redirects to somewhere else and answers with 302/303
3. Client follows and requests the next page (using GET at this point)
4. Server returns new page with HTTP 200
5. felf-cli takes this as a successful push

Closes #5.