### PR TITLE
chore: bump version (v1.0.0)

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ const (
 )
 
 const (
-	version = "v0.0.2"
+	version = "v1.0.0"
 )
 
 func main() { os.Exit(cli()) }


### PR DESCRIPTION
Not planning on being featured at 0ver.org so v1.0.0 is being released. At this point the product is already integrated with elfwatch-action, has been tested and has had a major bug fixed so it makes sense to tag it as v1.0.0.